### PR TITLE
Add Fund Seizure & Custom Errors to spdBTC

### DIFF
--- a/contracts/spdBTC/interfaces/IspdBTC.sol
+++ b/contracts/spdBTC/interfaces/IspdBTC.sol
@@ -12,3 +12,11 @@ struct ProductParams {
     uint256 maxDeposit;  // Maximum deposit amount.
     address custodian;   // Custodian address.
 }
+
+/**
+ * @dev Storage layout for the blacklist mapping.
+ * Uses a struct to store the mapping at a specific storage slot.
+ */
+struct BlacklistStorage {
+    mapping(address => bool) value;
+}

--- a/test/spdBTC.ts
+++ b/test/spdBTC.ts
@@ -91,7 +91,7 @@ describe('TokenMinter', function () {
 
     await expect(
       contracts.spdBtc.connect(user1).deposit(100, user2.address),
-    ).to.be.revertedWith('Address is blacklisted');
+    ).to.be.revertedWithCustomError(contracts.spdBtc, 'SenderBlacklisted');
   });
 
   it('Cannot deposit to blacklisted address', async function () {
@@ -105,7 +105,7 @@ describe('TokenMinter', function () {
 
     await expect(
       contracts.spdBtc.connect(user1).deposit(100, user2.address),
-    ).to.be.revertedWith('Receiver is blacklisted');
+    ).to.be.revertedWithCustomError(contracts.spdBtc, 'ReceiverBlacklisted');
   });
 
   it('Cannot transfer tokens to blacklisted address', async function () {
@@ -120,7 +120,7 @@ describe('TokenMinter', function () {
 
     await expect(
       contracts.spdBtc.connect(user1).transfer(user2.address, 50),
-    ).to.be.revertedWith('Receiver is blacklisted');
+    ).to.be.revertedWithCustomError(contracts.spdBtc, 'ReceiverBlacklisted');
   });
 
   it('Cannot transfer tokens from blacklisted address', async function () {
@@ -135,7 +135,7 @@ describe('TokenMinter', function () {
 
     await expect(
       contracts.spdBtc.connect(user1).transfer(user2.address, 50),
-    ).to.be.revertedWith('Address is blacklisted');
+    ).to.be.revertedWithCustomError(contracts.spdBtc, 'SenderBlacklisted');
   });
 
   it('Cannot transferFrom tokens to blacklisted address', async function () {
@@ -185,7 +185,7 @@ describe('TokenMinter', function () {
       contracts.spdBtc
         .connect(user1)
         .transferFrom(owner.address, user2.address, 50),
-    ).to.be.revertedWith('Address is blacklisted');
+    ).to.be.revertedWithCustomError(contracts.spdBtc, 'SenderBlacklisted');
   });
 
   it('Cannot transfer when paused', async function () {


### PR DESCRIPTION
This PR enhances the `spdBTC` contract by:

*   **Replacing `require` with Custom Errors:** Improves gas efficiency and revert clarity (e.g., `BelowMinDeposit`, `ReceiverBlacklisted`, `InsufficientAllowance`).
*   **Adding `seizeFunds` Function:** Allows the owner to seize tokens from blacklisted addresses and send them to the custodian. Emits `FundsSeized` event.
*   **Refactoring:** Moved `BlacklistStorage` struct to the interface file (`IspdBTC.sol`).
*   **Improving NatSpec:** Added/updated comments for clarity.